### PR TITLE
Fix issue #11

### DIFF
--- a/dnas/mrt_parser.py
+++ b/dnas/mrt_parser.py
@@ -14,6 +14,24 @@ class mrt_parser:
     """
 
     @staticmethod
+    def get_timestamp(filename):
+        """
+        Return the timestamp from the start of an MRT file.
+        """
+        _ = mrtparse.Reader(filename)
+        d = next(_).data["timestamp"]
+        ts = iter(d).__next__()
+        # Use the MRT file format timestamp:
+        timestamp = datetime.datetime.utcfromtimestamp(ts).strftime(
+            '%Y%m%d.%H%M'
+        )
+        try:
+            _.close()
+        except StopIteration:
+            pass
+        return timestamp
+
+    @staticmethod
     def parse_rib_dump(filename):
         """
         Take filename of RIB dump MRT as input and return an MRT stats obj.
@@ -39,7 +57,8 @@ class mrt_parser:
                 next_hop = None
 
                 for attr in rib_entry["path_attributes"]:
-                    attr_t = attr["type"][0]
+                    #attr_t = path_attr["type"][0]   ##### FIX ME
+                    attr_t = iter(path_attr["type"]).__next__()
 
                     # mrtparse.BGP_ATTR_T['AS_PATH']
                     if attr_t == 2:
@@ -167,7 +186,7 @@ class mrt_parser:
                     "withdraws": 0,
                 }
 
-            timestamp = mrt_e.data["timestamp"]
+            timestamp = mrt_parser.get_timestamp(filename)
 
             as_path = []
             comm_set = []
@@ -191,7 +210,8 @@ class mrt_parser:
                 prefixes = []
 
                 for path_attr in mrt_e.data["bgp_message"]["path_attributes"]:
-                    attr_t = path_attr["type"][0]
+                    #attr_t = path_attr["type"][0]   ##### FIX ME
+                    attr_t = iter(path_attr["type"]).__next__()
 
                     # AS_PATH
                     if attr_t == 2:

--- a/scripts/parse_mrts.py
+++ b/scripts/parse_mrts.py
@@ -137,7 +137,8 @@ def process_files(filelist, remove):
     for file in filelist:
         logging.info(f"Checking file {file}")
 
-        day_stats = rdb.get_stats(mrt_a.get_day_key(file))
+        day_key = mrt_a.get_day_key(file)
+        day_stats = rdb.get_stats(day_key)
 
         if day_stats:
             if file in day_stats.file_list:
@@ -201,16 +202,8 @@ def process_file(filename=None, keep_chunks=False):
     mrt_s = mrt_stats()
     for chunk in mrt_chunks:
         mrt_s.merge_in(chunk)
-    _ = mrtparse.Reader(filename)
-    ts = next(_).data["timestamp"][0]
-    mrt_s.timestamp = datetime.datetime.utcfromtimestamp(ts).strftime(
-        '%Y-%m-%d--%H-%M-%S'
-    )
-    try:
-        _.close()
-    except StopIteration:
-        pass
 
+    mrt_s.timestamp = mrt_parser.get_timestamp(filename)
     return mrt_s
 
 def main():


### PR DESCRIPTION
Fix issue #11 by extracting the dict key of the BGP path attribute dict, instead of expecting it to be a list. This pull request also fixes the same issue applies to timestamps, (expecting a list, but getting a dict, and it's the dict key we want to parse).